### PR TITLE
Reward boost pathing for bot

### DIFF
--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/AdvancedBoostPathingReward.cpp
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/AdvancedBoostPathingReward.cpp
@@ -1,0 +1,346 @@
+#include "AdvancedBoostPathingReward.h"
+#include <algorithm>
+#include <cmath>
+
+namespace RLGSC {
+
+	AdvancedBoostPathingReward::AdvancedBoostPathingReward(const Config& config) 
+		: config(config), currentTime(0.0f) {
+		InitializeBoostPadStates();
+	}
+
+	void AdvancedBoostPathingReward::InitializeBoostPadStates() {
+		boostPadStates.clear();
+		boostPadStates.reserve(CommonValues::BOOST_LOCATIONS_AMOUNT);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			BoostPadState padState;
+			padState.position = CommonValues::BOOST_LOCATIONS[i];
+			padState.isLargePad = IsLargePad(padState.position);
+			padState.cooldownTimer = 0.0f;
+			padState.isActive = true;
+			padState.lastCollectionTime = 0.0f;
+			padState.collectionCount = 0;
+			boostPadStates.push_back(padState);
+		}
+	}
+
+	bool AdvancedBoostPathingReward::IsLargePad(const Vec& position) const {
+		// Large boost pads are at corners and center
+		if (std::abs(position.x) < 50 && std::abs(position.y) < 50) {
+			return true; // Center pad
+		}
+		if (position.z > 70.5f) {
+			return true; // Corner pads (higher Z)
+		}
+		if (std::abs(position.y) > 4000) {
+			return true; // Back wall pads
+		}
+		return false;
+	}
+
+	bool AdvancedBoostPathingReward::IsBackWallPad(const Vec& position) const {
+		return std::abs(position.y) > 4000;
+	}
+
+	bool AdvancedBoostPathingReward::IsCenterPad(const Vec& position) const {
+		return std::abs(position.x) < 200 && std::abs(position.y) < 200;
+	}
+
+	void AdvancedBoostPathingReward::UpdateBoostPadStates(const GameState& state) {
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			auto& padState = boostPadStates[i];
+			
+			// Update active state
+			bool wasActive = padState.isActive;
+			padState.isActive = state.boostPads[i];
+			
+			// If pad just became active, update timing info
+			if (padState.isActive && !wasActive) {
+				padState.lastCollectionTime = currentTime;
+			}
+			
+			// Update cooldown timer
+			padState.cooldownTimer = state.boostPadTimers[i];
+		}
+	}
+
+	void AdvancedBoostPathingReward::Reset(const GameState& initialState) {
+		playerHistories.clear();
+		currentTime = 0.0f;
+		
+		// Initialize player histories
+		for (const auto& player : initialState.players) {
+			playerHistories[player.carId] = std::vector<PlayerBoostHistory>();
+		}
+		
+		// Reset boost pad states
+		InitializeBoostPadStates();
+	}
+
+	void AdvancedBoostPathingReward::PreStep(const GameState& state) {
+		currentTime += state.deltaTime;
+		UpdateBoostPadStates(state);
+		
+		// Update player histories
+		for (const auto& player : state.players) {
+			UpdatePlayerHistory(player, state);
+		}
+	}
+
+	void AdvancedBoostPathingReward::UpdatePlayerHistory(const PlayerData& player, const GameState& state) {
+		auto& history = playerHistories[player.carId];
+		
+		PlayerBoostHistory entry;
+		entry.position = player.phys.pos;
+		entry.boostFraction = player.boostFraction;
+		entry.timestamp = currentTime;
+		entry.nearbyPads.resize(CommonValues::BOOST_LOCATIONS_AMOUNT, false);
+		
+		// Calculate which pads are nearby
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				entry.nearbyPads[i] = IsPadNearby(player.phys.pos, boostPadStates[i].position);
+			}
+		}
+		
+		history.push_back(entry);
+		
+		// Keep only recent history (last 2 seconds)
+		while (history.size() > 1 && (currentTime - history[0].timestamp) > 2.0f) {
+			history.erase(history.begin());
+		}
+	}
+
+	float AdvancedBoostPathingReward::GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) {
+		float totalReward = 0.0f;
+
+		// Calculate all reward components
+		totalReward += CalculateProximityReward(player, state);
+		totalReward += CalculateCollectionReward(player, state);
+		totalReward += CalculatePathingReward(player, state);
+		totalReward += CalculateTimingReward(player, state);
+		totalReward += CalculateEfficiencyReward(player, state);
+		totalReward += CalculateStrategicReward(player, state);
+
+		return totalReward;
+	}
+
+	float AdvancedBoostPathingReward::CalculateProximityReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		auto distances = CalculatePadDistances(player.phys.pos, state);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i] && distances[i] <= config.proximityThreshold) {
+				float proximityFactor = 1.0f - (distances[i] / config.proximityThreshold);
+				proximityFactor = std::max(0.0f, std::min(1.0f, proximityFactor));
+				
+				float padMultiplier = GetPadPreferenceMultiplier(boostPadStates[i].position);
+				reward += config.proximityReward * proximityFactor * padMultiplier;
+			}
+		}
+
+		return reward;
+	}
+
+	float AdvancedBoostPathingReward::CalculateCollectionReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		auto& history = playerHistories[player.carId];
+		
+		if (history.size() < 2) return 0.0f;
+		
+		// Check if player collected any boost pads
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				Vec padPos = boostPadStates[i].position;
+				
+				// Check if player is close enough to collect
+				if (IsPadCollectible(player.phys.pos, padPos)) {
+					// Check if this pad was nearby in previous frame (indicating intentional collection)
+					if (history.size() > 1 && history[history.size() - 2].nearbyPads[i]) {
+						float padMultiplier = GetPadPreferenceMultiplier(padPos);
+						reward += config.collectionReward * padMultiplier;
+						
+						// Update collection count
+						boostPadStates[i].collectionCount++;
+					}
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	float AdvancedBoostPathingReward::CalculatePathingReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		auto& history = playerHistories[player.carId];
+		
+		if (history.size() < 2) return 0.0f;
+		
+		Vec currentPos = player.phys.pos;
+		Vec lastPos = history[history.size() - 2].position;
+		
+		// Check if player is moving toward nearby boost pads
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				Vec padPos = boostPadStates[i].position;
+				float distance = currentPos.Dist2D(padPos);
+				
+				if (distance <= config.proximityThreshold) {
+					// Calculate if player is moving toward the pad
+					Vec directionToPad = (padPos - currentPos).Normalized();
+					Vec playerMovement = (currentPos - lastPos).Normalized();
+					
+					float alignment = directionToPad.Dot(playerMovement);
+					
+					if (alignment > 0.2f) { // Moving toward the pad
+						float distanceFactor = 1.0f - (distance / config.proximityThreshold);
+						distanceFactor = std::max(0.0f, std::min(1.0f, distanceFactor));
+						
+						float padMultiplier = GetPadPreferenceMultiplier(padPos);
+						reward += config.pathingReward * alignment * distanceFactor * padMultiplier;
+					}
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	float AdvancedBoostPathingReward::CalculateTimingReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		
+		// Check if player collected pads just as they spawned
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				auto& padState = boostPadStates[i];
+				
+				// Check if pad was recently spawned
+				float timeSinceSpawn = currentTime - padState.lastCollectionTime;
+				if (timeSinceSpawn <= config.timingWindow) {
+					Vec padPos = padState.position;
+					
+					// Check if player is near this recently spawned pad
+					if (IsPadNearby(player.phys.pos, padPos)) {
+						float timingFactor = 1.0f - (timeSinceSpawn / config.timingWindow);
+						float padMultiplier = GetPadPreferenceMultiplier(padPos);
+						reward += config.timingReward * timingFactor * padMultiplier;
+					}
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	float AdvancedBoostPathingReward::CalculateEfficiencyReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		
+		// Reward for efficient boost usage when boost is low
+		if (player.boostFraction < config.boostEfficiencyThreshold) {
+			// Check if player is near boost pads when they need boost
+			bool nearBoostPad = false;
+			for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+				if (state.boostPads[i] && IsPadNearby(player.phys.pos, boostPadStates[i].position)) {
+					nearBoostPad = true;
+					break;
+				}
+			}
+
+			if (nearBoostPad) {
+				// Reward for being near boost when low on boost
+				reward += config.efficiencyReward * (1.0f - player.boostFraction);
+			}
+		}
+
+		return reward;
+	}
+
+	float AdvancedBoostPathingReward::CalculateStrategicReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		auto priorities = CalculatePadPriorities(player.phys.pos, state);
+		
+		// Reward for choosing strategic boost pads
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i] && IsPadNearby(player.phys.pos, boostPadStates[i].position)) {
+				Vec padPos = boostPadStates[i].position;
+				float priority = priorities[i];
+				
+				// Reward for choosing high-priority pads
+				if (priority > 0.7f) {
+					float padMultiplier = GetPadPreferenceMultiplier(padPos);
+					reward += config.strategicReward * priority * padMultiplier;
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	std::vector<float> AdvancedBoostPathingReward::CalculatePadDistances(const Vec& playerPos, const GameState& state) {
+		std::vector<float> distances;
+		distances.reserve(CommonValues::BOOST_LOCATIONS_AMOUNT);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				float distance = playerPos.Dist2D(boostPadStates[i].position);
+				distances.push_back(distance);
+			} else {
+				distances.push_back(std::numeric_limits<float>::max());
+			}
+		}
+
+		return distances;
+	}
+
+	std::vector<float> AdvancedBoostPathingReward::CalculatePadPriorities(const Vec& playerPos, const GameState& state) {
+		std::vector<float> priorities;
+		priorities.reserve(CommonValues::BOOST_LOCATIONS_AMOUNT);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				Vec padPos = boostPadStates[i].position;
+				float distance = playerPos.Dist2D(padPos);
+				
+				// Calculate priority based on distance and pad type
+				float distancePriority = 1.0f - (distance / 5000.0f); // Normalize by field size
+				distancePriority = std::max(0.0f, std::min(1.0f, distancePriority));
+				
+				float typePriority = boostPadStates[i].isLargePad ? 1.0f : 0.5f;
+				float locationPriority = GetPadPreferenceMultiplier(padPos) / config.largePadPreference;
+				
+				float priority = (distancePriority + typePriority + locationPriority) / 3.0f;
+				priorities.push_back(priority);
+			} else {
+				priorities.push_back(0.0f);
+			}
+		}
+
+		return priorities;
+	}
+
+	bool AdvancedBoostPathingReward::IsPadNearby(const Vec& playerPos, const Vec& padPos) const {
+		return playerPos.Dist2D(padPos) <= config.proximityThreshold;
+	}
+
+	bool AdvancedBoostPathingReward::IsPadCollectible(const Vec& playerPos, const Vec& padPos) const {
+		return playerPos.Dist2D(padPos) <= config.collectionThreshold;
+	}
+
+	float AdvancedBoostPathingReward::GetPadPreferenceMultiplier(const Vec& padPos) const {
+		float multiplier = 1.0f;
+		
+		if (IsLargePad(padPos)) {
+			multiplier *= config.largePadPreference;
+		}
+		if (IsBackWallPad(padPos)) {
+			multiplier *= config.backWallPreference;
+		}
+		if (IsCenterPad(padPos)) {
+			multiplier *= config.centerPreference;
+		}
+		
+		return multiplier;
+	}
+
+}

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/AdvancedBoostPathingReward.h
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/AdvancedBoostPathingReward.h
@@ -1,0 +1,85 @@
+#pragma once
+#include "RewardFunction.h"
+#include "../CommonValues.h"
+#include <unordered_map>
+#include <vector>
+
+namespace RLGSC {
+	// Advanced boost pathing reward function with timing and strategic considerations
+	class AdvancedBoostPathingReward : public RewardFunction {
+	public:
+		struct BoostPadState {
+			Vec position;
+			bool isLargePad;
+			float cooldownTimer;
+			bool isActive;
+			float lastCollectionTime;
+			int collectionCount;
+		};
+
+		struct PlayerBoostHistory {
+			Vec position;
+			float boostFraction;
+			float timestamp;
+			std::vector<bool> nearbyPads;
+		};
+
+		struct Config {
+			// Basic rewards
+			float proximityReward = 0.05f;
+			float collectionReward = 1.0f;
+			float pathingReward = 0.03f;
+			
+			// Timing-based rewards
+			float timingReward = 0.2f;           // Reward for collecting pads just as they spawn
+			float efficiencyReward = 0.15f;      // Reward for efficient boost usage
+			float strategicReward = 0.1f;        // Reward for strategic pad selection
+			
+			// Thresholds
+			float proximityThreshold = 400.0f;
+			float collectionThreshold = 120.0f;
+			float boostEfficiencyThreshold = 0.4f;
+			float timingWindow = 0.5f;           // seconds after pad spawn to get timing reward
+			
+			// Strategic parameters
+			float largePadPreference = 2.0f;     // Multiplier for preferring large pads
+			float backWallPreference = 1.5f;     // Multiplier for back wall pads
+			float centerPreference = 1.3f;       // Multiplier for center pads
+		};
+
+		AdvancedBoostPathingReward(const Config& config = Config{});
+
+		virtual void Reset(const GameState& initialState) override;
+		virtual void PreStep(const GameState& state) override;
+		virtual float GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) override;
+
+	private:
+		Config config;
+		std::unordered_map<uint32_t, std::vector<PlayerBoostHistory>> playerHistories;
+		std::vector<BoostPadState> boostPadStates;
+		float currentTime;
+
+		// Helper functions
+		void InitializeBoostPadStates();
+		void UpdateBoostPadStates(const GameState& state);
+		bool IsLargePad(const Vec& position) const;
+		bool IsBackWallPad(const Vec& position) const;
+		bool IsCenterPad(const Vec& position) const;
+		
+		// Reward calculation functions
+		float CalculateProximityReward(const PlayerData& player, const GameState& state);
+		float CalculateCollectionReward(const PlayerData& player, const GameState& state);
+		float CalculatePathingReward(const PlayerData& player, const GameState& state);
+		float CalculateTimingReward(const PlayerData& player, const GameState& state);
+		float CalculateEfficiencyReward(const PlayerData& player, const GameState& state);
+		float CalculateStrategicReward(const PlayerData& player, const GameState& state);
+		
+		// Utility functions
+		std::vector<float> CalculatePadDistances(const Vec& playerPos, const GameState& state);
+		std::vector<float> CalculatePadPriorities(const Vec& playerPos, const GameState& state);
+		bool IsPadNearby(const Vec& playerPos, const Vec& padPos) const;
+		bool IsPadCollectible(const Vec& playerPos, const Vec& padPos) const;
+		float GetPadPreferenceMultiplier(const Vec& padPos) const;
+		void UpdatePlayerHistory(const PlayerData& player, const GameState& state);
+	};
+}

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingExample.cpp
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingExample.cpp
@@ -1,0 +1,231 @@
+#include "BoostPathingReward.h"
+#include "AdvancedBoostPathingReward.h"
+#include "CombinedReward.h"
+#include "CommonRewards.h"
+#include "../Gamestates/GameState.h"
+#include <memory>
+
+// Example of how to use the boost pathing reward functions
+namespace RLGSC {
+	namespace BoostPathingExamples {
+		
+		// Example 1: Basic boost pathing reward
+		std::shared_ptr<RewardFunction> CreateBasicBoostPathingReward() {
+			BoostPathingReward::Config config;
+			config.proximityReward = 0.1f;
+			config.collectionReward = 1.0f;
+			config.pathingReward = 0.05f;
+			config.efficiencyReward = 0.2f;
+			config.proximityThreshold = 300.0f;
+			config.collectionThreshold = 100.0f;
+			config.boostEfficiencyThreshold = 0.3f;
+			
+			return std::make_shared<BoostPathingReward>(config);
+		}
+		
+		// Example 2: Advanced boost pathing reward with timing
+		std::shared_ptr<RewardFunction> CreateAdvancedBoostPathingReward() {
+			AdvancedBoostPathingReward::Config config;
+			config.proximityReward = 0.05f;
+			config.collectionReward = 1.0f;
+			config.pathingReward = 0.03f;
+			config.timingReward = 0.2f;
+			config.efficiencyReward = 0.15f;
+			config.strategicReward = 0.1f;
+			config.proximityThreshold = 400.0f;
+			config.collectionThreshold = 120.0f;
+			config.boostEfficiencyThreshold = 0.4f;
+			config.timingWindow = 0.5f;
+			config.largePadPreference = 2.0f;
+			config.backWallPreference = 1.5f;
+			config.centerPreference = 1.3f;
+			
+			return std::make_shared<AdvancedBoostPathingReward>(config);
+		}
+		
+		// Example 3: Combined reward with boost pathing and other rewards
+		std::shared_ptr<RewardFunction> CreateCombinedBoostPathingReward() {
+			// Create boost pathing reward
+			auto boostPathing = CreateAdvancedBoostPathingReward();
+			
+			// Create other common rewards
+			auto velocityReward = std::make_shared<VelocityReward>(false);
+			auto saveBoostReward = std::make_shared<SaveBoostReward>(0.5f);
+			auto touchBallReward = std::make_shared<TouchBallReward>(0.0f);
+			
+			// Create event reward for goals, touches, etc.
+			EventReward::WeightScales eventScales;
+			eventScales.goal = 10.0f;
+			eventScales.teamGoal = 5.0f;
+			eventScales.concede = -5.0f;
+			eventScales.touch = 0.1f;
+			eventScales.shot = 1.0f;
+			eventScales.save = 1.0f;
+			eventScales.boostPickup = 0.5f;
+			auto eventReward = std::make_shared<EventReward>(eventScales);
+			
+			// Combine all rewards
+			std::vector<std::shared_ptr<RewardFunction>> rewards = {
+				boostPathing,
+				velocityReward,
+				saveBoostReward,
+				touchBallReward,
+				eventReward
+			};
+			
+			return std::make_shared<CombinedReward>(rewards);
+		}
+		
+		// Example 4: Specialized boost pathing for different play styles
+		std::shared_ptr<RewardFunction> CreateAggressiveBoostPathingReward() {
+			AdvancedBoostPathingReward::Config config;
+			// Aggressive settings - prioritize large pads and timing
+			config.proximityReward = 0.03f;
+			config.collectionReward = 1.5f;
+			config.pathingReward = 0.05f;
+			config.timingReward = 0.3f;
+			config.efficiencyReward = 0.1f;
+			config.strategicReward = 0.15f;
+			config.proximityThreshold = 500.0f;
+			config.collectionThreshold = 150.0f;
+			config.boostEfficiencyThreshold = 0.5f;
+			config.timingWindow = 0.3f;
+			config.largePadPreference = 3.0f;  // Strong preference for large pads
+			config.backWallPreference = 2.0f;
+			config.centerPreference = 1.5f;
+			
+			return std::make_shared<AdvancedBoostPathingReward>(config);
+		}
+		
+		std::shared_ptr<RewardFunction> CreateConservativeBoostPathingReward() {
+			AdvancedBoostPathingReward::Config config;
+			// Conservative settings - prioritize efficiency and small pads
+			config.proximityReward = 0.08f;
+			config.collectionReward = 0.8f;
+			config.pathingReward = 0.04f;
+			config.timingReward = 0.1f;
+			config.efficiencyReward = 0.25f;
+			config.strategicReward = 0.08f;
+			config.proximityThreshold = 350.0f;
+			config.collectionThreshold = 100.0f;
+			config.boostEfficiencyThreshold = 0.3f;
+			config.timingWindow = 0.8f;
+			config.largePadPreference = 1.5f;
+			config.backWallPreference = 1.2f;
+			config.centerPreference = 1.1f;
+			
+			return std::make_shared<AdvancedBoostPathingReward>(config);
+		}
+		
+		// Example 5: Boost pathing with team coordination
+		std::shared_ptr<RewardFunction> CreateTeamBoostPathingReward() {
+			// This would require additional logic for team coordination
+			// For now, we'll use the advanced reward with team-friendly settings
+			AdvancedBoostPathingReward::Config config;
+			config.proximityReward = 0.06f;
+			config.collectionReward = 1.2f;
+			config.pathingReward = 0.04f;
+			config.timingReward = 0.15f;
+			config.efficiencyReward = 0.2f;
+			config.strategicReward = 0.12f;
+			config.proximityThreshold = 450.0f;
+			config.collectionThreshold = 130.0f;
+			config.boostEfficiencyThreshold = 0.35f;
+			config.timingWindow = 0.6f;
+			config.largePadPreference = 2.5f;
+			config.backWallPreference = 1.8f;
+			config.centerPreference = 1.4f;
+			
+			return std::make_shared<AdvancedBoostPathingReward>(config);
+		}
+	}
+}
+
+/*
+Boost Pathing Reward Function Documentation
+
+This implementation provides comprehensive boost pathing rewards for Rocket League bots.
+The reward functions encourage efficient boost collection behavior through multiple mechanisms:
+
+1. Proximity Rewards:
+   - Rewards the agent for being near active boost pads
+   - Higher rewards for large pads (100 boost) vs small pads (12 boost)
+   - Distance-based scaling (closer = higher reward)
+
+2. Collection Rewards:
+   - Rewards successful boost pad collection
+   - Only rewards intentional collection (pad was nearby in previous frame)
+   - Multipliers for different pad types
+
+3. Pathing Rewards:
+   - Rewards movement toward nearby boost pads
+   - Uses dot product to measure alignment with pad direction
+   - Distance-based scaling
+
+4. Timing Rewards (Advanced):
+   - Rewards collecting pads just as they spawn
+   - Encourages efficient timing and prediction
+   - Higher rewards for quick collection after spawn
+
+5. Efficiency Rewards:
+   - Rewards being near boost when boost is low
+   - Encourages proactive boost management
+   - Prevents boost starvation
+
+6. Strategic Rewards (Advanced):
+   - Rewards choosing high-priority boost pads
+   - Considers pad type, location, and distance
+   - Encourages strategic decision making
+
+Configuration Parameters:
+
+Basic Parameters:
+- proximityReward: Reward for being near boost pads
+- collectionReward: Reward for collecting boost pads
+- pathingReward: Reward for moving toward boost pads
+- efficiencyReward: Reward for efficient boost usage
+- proximityThreshold: Distance threshold for "nearby" pads
+- collectionThreshold: Distance threshold for collection
+- boostEfficiencyThreshold: Boost level below which efficiency is rewarded
+
+Advanced Parameters:
+- timingReward: Reward for collecting pads just as they spawn
+- strategicReward: Reward for strategic pad selection
+- timingWindow: Time window after spawn for timing rewards
+- largePadPreference: Multiplier for large pad preference
+- backWallPreference: Multiplier for back wall pad preference
+- centerPreference: Multiplier for center pad preference
+
+Usage Examples:
+
+1. Basic boost pathing:
+   auto reward = BoostPathingExamples::CreateBasicBoostPathingReward();
+
+2. Advanced boost pathing with timing:
+   auto reward = BoostPathingExamples::CreateAdvancedBoostPathingReward();
+
+3. Combined with other rewards:
+   auto reward = BoostPathingExamples::CreateCombinedBoostPathingReward();
+
+4. Aggressive play style:
+   auto reward = BoostPathingExamples::CreateAggressiveBoostPathingReward();
+
+5. Conservative play style:
+   auto reward = BoostPathingExamples::CreateConservativeBoostPathingReward();
+
+Boost Pad Locations:
+The system uses the standard Rocket League boost pad locations:
+- 34 total boost pads
+- Large pads (100 boost): Center, corners, back walls
+- Small pads (12 boost): Throughout the field
+- All positions are hardcoded in CommonValues::BOOST_LOCATIONS
+
+The reward functions automatically handle:
+- Boost pad state tracking (active/inactive)
+- Cooldown timers
+- Player position and movement
+- Boost fraction tracking
+- Historical data for intentional collection detection
+
+This implementation provides a solid foundation for training Rocket League bots with sophisticated boost management skills.
+*/

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingReward.cpp
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingReward.cpp
@@ -1,0 +1,230 @@
+#include "BoostPathingReward.h"
+#include <algorithm>
+#include <cmath>
+
+namespace RLGSC {
+
+	BoostPathingReward::BoostPathingReward(const Config& config) : config(config) {
+		InitializeBoostPadInfos();
+	}
+
+	void BoostPathingReward::InitializeBoostPadInfos() {
+		boostPadInfos.clear();
+		boostPadInfos.reserve(CommonValues::BOOST_LOCATIONS_AMOUNT);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			BoostPadInfo padInfo;
+			padInfo.position = CommonValues::BOOST_LOCATIONS[i];
+			padInfo.isLargePad = IsLargePad(padInfo.position);
+			padInfo.collectionRadius = padInfo.isLargePad ? 150.0f : 120.0f; // Large pads have larger collection radius
+			boostPadInfos.push_back(padInfo);
+		}
+	}
+
+	bool BoostPathingReward::IsLargePad(const Vec& position) const {
+		// Large boost pads are typically at the corners and center of the field
+		// Based on the boost pad locations, large pads are at:
+		// - Center field (0, 0, 73)
+		// - Corner positions with higher Z coordinates (73 instead of 70)
+		// - Back wall positions
+		
+		// Check if it's a center pad
+		if (std::abs(position.x) < 50 && std::abs(position.y) < 50) {
+			return true;
+		}
+
+		// Check if it's a corner pad (higher Z coordinate)
+		if (position.z > 70.5f) {
+			return true;
+		}
+
+		// Check if it's a back wall pad
+		if (std::abs(position.y) > 4000) {
+			return true;
+		}
+
+		return false;
+	}
+
+	void BoostPathingReward::Reset(const GameState& initialState) {
+		playerStates.clear();
+		
+		// Initialize player states
+		for (const auto& player : initialState.players) {
+			PlayerBoostState state;
+			state.lastPosition = player.phys.pos;
+			state.lastBoostFraction = player.boostFraction;
+			state.boostPickups = player.boostPickups;
+			state.nearbyPads.resize(CommonValues::BOOST_LOCATIONS_AMOUNT, false);
+			state.padDistances.resize(CommonValues::BOOST_LOCATIONS_AMOUNT, 0.0f);
+			playerStates[player.carId] = state;
+		}
+	}
+
+	void BoostPathingReward::PreStep(const GameState& state) {
+		// Update player states with current information
+		for (const auto& player : state.players) {
+			auto& playerState = playerStates[player.carId];
+			
+			// Calculate distances to all boost pads
+			playerState.padDistances = CalculatePadDistances(player.phys.pos, state);
+			
+			// Update nearby pad flags
+			for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+				if (state.boostPads[i]) { // Only consider active pads
+					playerState.nearbyPads[i] = IsPadNearby(player.phys.pos, boostPadInfos[i].position);
+				} else {
+					playerState.nearbyPads[i] = false;
+				}
+			}
+		}
+	}
+
+	float BoostPathingReward::GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) {
+		float totalReward = 0.0f;
+
+		// Calculate different components of the reward
+		totalReward += CalculateProximityReward(player, state);
+		totalReward += CalculatePathingReward(player, state);
+		totalReward += CalculateEfficiencyReward(player, state);
+		totalReward += CalculateCollectionReward(player, state);
+
+		// Update player state for next frame
+		auto& playerState = playerStates[player.carId];
+		playerState.lastPosition = player.phys.pos;
+		playerState.lastBoostFraction = player.boostFraction;
+		playerState.boostPickups = player.boostPickups;
+
+		return totalReward;
+	}
+
+	float BoostPathingReward::CalculateProximityReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		const auto& playerState = playerStates[player.carId];
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i] && playerState.nearbyPads[i]) {
+				// Reward for being near an active boost pad
+				float distance = playerState.padDistances[i];
+				float proximityFactor = 1.0f - (distance / config.proximityThreshold);
+				proximityFactor = std::max(0.0f, std::min(1.0f, proximityFactor));
+				
+				// Give higher reward for large pads
+				float padMultiplier = boostPadInfos[i].isLargePad ? 2.0f : 1.0f;
+				reward += config.proximityReward * proximityFactor * padMultiplier;
+			}
+		}
+
+		return reward;
+	}
+
+	float BoostPathingReward::CalculatePathingReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		const auto& playerState = playerStates[player.carId];
+		Vec currentPos = player.phys.pos;
+		Vec lastPos = playerState.lastPosition;
+
+		// Check if player is moving toward nearby boost pads
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i] && playerState.nearbyPads[i]) {
+				Vec padPos = boostPadInfos[i].position;
+				
+				// Calculate if player is moving toward the pad
+				Vec directionToPad = (padPos - currentPos).Normalized();
+				Vec playerMovement = (currentPos - lastPos).Normalized();
+				
+				// Dot product indicates alignment (1 = moving directly toward, -1 = moving away)
+				float alignment = directionToPad.Dot(playerMovement);
+				
+				if (alignment > 0.3f) { // Moving toward the pad
+					float distance = playerState.padDistances[i];
+					float distanceFactor = 1.0f - (distance / config.proximityThreshold);
+					distanceFactor = std::max(0.0f, std::min(1.0f, distanceFactor));
+					
+					float padMultiplier = boostPadInfos[i].isLargePad ? 1.5f : 1.0f;
+					reward += config.pathingReward * alignment * distanceFactor * padMultiplier;
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	float BoostPathingReward::CalculateEfficiencyReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		const auto& playerState = playerStates[player.carId];
+
+		// Reward for efficient boost usage when boost is low
+		if (player.boostFraction < config.boostEfficiencyThreshold) {
+			// Check if player is near boost pads when they need boost
+			bool nearBoostPad = false;
+			for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+				if (state.boostPads[i] && playerState.nearbyPads[i]) {
+					nearBoostPad = true;
+					break;
+				}
+			}
+
+			if (nearBoostPad) {
+				// Reward for being near boost when low on boost
+				reward += config.efficiencyReward * (1.0f - player.boostFraction);
+			}
+		}
+
+		return reward;
+	}
+
+	float BoostPathingReward::CalculateCollectionReward(const PlayerData& player, const GameState& state) {
+		float reward = 0.0f;
+		const auto& playerState = playerStates[player.carId];
+
+		// Check if player collected any boost pads
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				Vec padPos = boostPadInfos[i].position;
+				
+				// Check if player is close enough to collect the pad
+				if (IsPadCollectible(player.phys.pos, padPos)) {
+					// Check if this pad was nearby in the previous frame (indicating intentional collection)
+					if (playerState.nearbyPads[i]) {
+						float padMultiplier = boostPadInfos[i].isLargePad ? 3.0f : 1.0f;
+						reward += config.collectionReward * padMultiplier;
+					}
+				}
+			}
+		}
+
+		return reward;
+	}
+
+	std::vector<float> BoostPathingReward::CalculatePadDistances(const Vec& playerPos, const GameState& state) {
+		std::vector<float> distances;
+		distances.reserve(CommonValues::BOOST_LOCATIONS_AMOUNT);
+
+		for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+			if (state.boostPads[i]) {
+				float distance = playerPos.Dist2D(boostPadInfos[i].position);
+				distances.push_back(distance);
+			} else {
+				distances.push_back(std::numeric_limits<float>::max()); // Pad not available
+			}
+		}
+
+		return distances;
+	}
+
+	bool BoostPathingReward::IsPadNearby(const Vec& playerPos, const Vec& padPos) const {
+		return playerPos.Dist2D(padPos) <= config.proximityThreshold;
+	}
+
+	bool BoostPathingReward::IsPadCollectible(const Vec& playerPos, const Vec& padPos) const {
+		// Find the pad info for this position
+		for (const auto& padInfo : boostPadInfos) {
+			if (padInfo.position.Dist2D(padPos) < 10.0f) { // Close enough to be the same pad
+				return playerPos.Dist2D(padPos) <= padInfo.collectionRadius;
+			}
+		}
+		return false;
+	}
+
+}

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingReward.h
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingReward.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "RewardFunction.h"
+#include "../CommonValues.h"
+#include <unordered_map>
+
+namespace RLGSC {
+	// Boost pathing reward function that rewards efficient boost collection
+	class BoostPathingReward : public RewardFunction {
+	public:
+		struct BoostPadInfo {
+			Vec position;
+			bool isLargePad;  // true for 100 boost pads, false for 12 boost pads
+			float collectionRadius;  // radius within which the pad can be collected
+		};
+
+		struct PlayerBoostState {
+			Vec lastPosition;
+			float lastBoostFraction;
+			int boostPickups;
+			std::vector<bool> nearbyPads;  // tracks which pads were nearby last frame
+			std::vector<float> padDistances;  // distance to each pad
+		};
+
+		// Configuration parameters
+		struct Config {
+			float proximityReward = 0.1f;        // reward for being near a boost pad
+			float collectionReward = 1.0f;       // reward for collecting a boost pad
+			float pathingReward = 0.05f;         // reward for moving toward nearby pads
+			float efficiencyReward = 0.2f;       // reward for efficient boost usage
+			float proximityThreshold = 300.0f;   // distance threshold for "nearby" pads
+			float collectionThreshold = 100.0f;  // distance threshold for collection
+			float boostEfficiencyThreshold = 0.3f; // boost level below which efficiency is rewarded
+		};
+
+		BoostPathingReward(const Config& config = Config{});
+
+		virtual void Reset(const GameState& initialState) override;
+		virtual void PreStep(const GameState& state) override;
+		virtual float GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) override;
+
+	private:
+		Config config;
+		std::unordered_map<uint32_t, PlayerBoostState> playerStates;
+		std::vector<BoostPadInfo> boostPadInfos;
+
+		// Helper functions
+		void InitializeBoostPadInfos();
+		bool IsLargePad(const Vec& position) const;
+		float CalculateProximityReward(const PlayerData& player, const GameState& state);
+		float CalculatePathingReward(const PlayerData& player, const GameState& state);
+		float CalculateEfficiencyReward(const PlayerData& player, const GameState& state);
+		float CalculateCollectionReward(const PlayerData& player, const GameState& state);
+		std::vector<float> CalculatePadDistances(const Vec& playerPos, const GameState& state);
+		bool IsPadNearby(const Vec& playerPos, const Vec& padPos) const;
+		bool IsPadCollectible(const Vec& playerPos, const Vec& padPos) const;
+	};
+}

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingTest.cpp
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/BoostPathingTest.cpp
@@ -1,0 +1,198 @@
+#include "BoostPathingReward.h"
+#include "AdvancedBoostPathingReward.h"
+#include "../Gamestates/GameState.h"
+#include "../BasicTypes/Action.h"
+#include <iostream>
+#include <memory>
+
+// Simple test to demonstrate boost pathing reward functions
+namespace RLGSC {
+	namespace BoostPathingTest {
+		
+		void TestBasicBoostPathing() {
+			std::cout << "Testing Basic Boost Pathing Reward..." << std::endl;
+			
+			// Create reward function
+			BoostPathingReward::Config config;
+			config.proximityReward = 0.1f;
+			config.collectionReward = 1.0f;
+			config.pathingReward = 0.05f;
+			config.efficiencyReward = 0.2f;
+			config.proximityThreshold = 300.0f;
+			config.collectionThreshold = 100.0f;
+			config.boostEfficiencyThreshold = 0.3f;
+			
+			auto reward = std::make_shared<BoostPathingReward>(config);
+			
+			// Create test game state
+			GameState state;
+			state.deltaTime = 1.0f / 120.0f; // 120 FPS
+			
+			// Add a test player
+			PlayerData player;
+			player.carId = 1;
+			player.team = Team::BLUE;
+			player.phys.pos = Vec(0, 0, 0); // Center of field
+			player.boostFraction = 0.5f;
+			player.boostPickups = 0;
+			state.players.push_back(player);
+			
+			// Set up boost pads (activate some pads)
+			for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+				state.boostPads[i] = (i % 3 == 0); // Activate every 3rd pad
+				state.boostPadTimers[i] = 0.0f;
+			}
+			
+			// Create test action
+			Action action;
+			action.throttle = 1.0f;
+			action.steer = 0.0f;
+			action.pitch = 0.0f;
+			action.yaw = 0.0f;
+			action.roll = 0.0f;
+			action.jump = false;
+			action.boost = false;
+			action.handbrake = false;
+			
+			// Initialize reward function
+			reward->Reset(state);
+			
+			// Test reward calculation
+			float rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Basic reward value: " << rewardValue << std::endl;
+			
+			// Test with player near a boost pad
+			player.phys.pos = CommonValues::BOOST_LOCATIONS[0]; // Move to first boost pad
+			state.players[0] = player;
+			
+			rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Reward near boost pad: " << rewardValue << std::endl;
+			
+			// Test with low boost
+			player.boostFraction = 0.1f;
+			state.players[0] = player;
+			
+			rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Reward with low boost: " << rewardValue << std::endl;
+		}
+		
+		void TestAdvancedBoostPathing() {
+			std::cout << "\nTesting Advanced Boost Pathing Reward..." << std::endl;
+			
+			// Create reward function
+			AdvancedBoostPathingReward::Config config;
+			config.proximityReward = 0.05f;
+			config.collectionReward = 1.0f;
+			config.pathingReward = 0.03f;
+			config.timingReward = 0.2f;
+			config.efficiencyReward = 0.15f;
+			config.strategicReward = 0.1f;
+			config.proximityThreshold = 400.0f;
+			config.collectionThreshold = 120.0f;
+			config.boostEfficiencyThreshold = 0.4f;
+			config.timingWindow = 0.5f;
+			config.largePadPreference = 2.0f;
+			config.backWallPreference = 1.5f;
+			config.centerPreference = 1.3f;
+			
+			auto reward = std::make_shared<AdvancedBoostPathingReward>(config);
+			
+			// Create test game state
+			GameState state;
+			state.deltaTime = 1.0f / 120.0f;
+			
+			// Add a test player
+			PlayerData player;
+			player.carId = 1;
+			player.team = Team::BLUE;
+			player.phys.pos = Vec(0, 0, 0);
+			player.boostFraction = 0.5f;
+			player.boostPickups = 0;
+			state.players.push_back(player);
+			
+			// Set up boost pads
+			for (int i = 0; i < CommonValues::BOOST_LOCATIONS_AMOUNT; i++) {
+				state.boostPads[i] = (i % 2 == 0); // Activate every 2nd pad
+				state.boostPadTimers[i] = 0.0f;
+			}
+			
+			// Create test action
+			Action action;
+			action.throttle = 1.0f;
+			action.steer = 0.0f;
+			action.pitch = 0.0f;
+			action.yaw = 0.0f;
+			action.roll = 0.0f;
+			action.jump = false;
+			action.boost = false;
+			action.handbrake = false;
+			
+			// Initialize reward function
+			reward->Reset(state);
+			
+			// Test reward calculation
+			float rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Advanced reward value: " << rewardValue << std::endl;
+			
+			// Test with player near a large boost pad (center)
+			player.phys.pos = Vec(0, 0, 73); // Center large pad
+			state.players[0] = player;
+			
+			rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Reward near large pad: " << rewardValue << std::endl;
+			
+			// Test with player near a back wall pad
+			player.phys.pos = Vec(0, 4240, 70); // Back wall pad
+			state.players[0] = player;
+			
+			rewardValue = reward->GetReward(player, state, action);
+			std::cout << "Reward near back wall pad: " << rewardValue << std::endl;
+		}
+		
+		void TestBoostPadDetection() {
+			std::cout << "\nTesting Boost Pad Detection..." << std::endl;
+			
+			// Test large pad detection
+			AdvancedBoostPathingReward::Config config;
+			auto reward = std::make_shared<AdvancedBoostPathingReward>(config);
+			
+			// Test center pad
+			Vec centerPad(0, 0, 73);
+			bool isLarge = reward->IsLargePad(centerPad);
+			std::cout << "Center pad (0, 0, 73) is large: " << (isLarge ? "Yes" : "No") << std::endl;
+			
+			// Test corner pad
+			Vec cornerPad(-3072, -4096, 73);
+			isLarge = reward->IsLargePad(cornerPad);
+			std::cout << "Corner pad (-3072, -4096, 73) is large: " << (isLarge ? "Yes" : "No") << std::endl;
+			
+			// Test back wall pad
+			Vec backWallPad(0, 4240, 70);
+			isLarge = reward->IsLargePad(backWallPad);
+			std::cout << "Back wall pad (0, 4240, 70) is large: " << (isLarge ? "Yes" : "No") << std::endl;
+			
+			// Test small pad
+			Vec smallPad(1024, 0, 70);
+			isLarge = reward->IsLargePad(smallPad);
+			std::cout << "Small pad (1024, 0, 70) is large: " << (isLarge ? "Yes" : "No") << std::endl;
+		}
+		
+		void RunAllTests() {
+			std::cout << "=== Boost Pathing Reward Function Tests ===" << std::endl;
+			
+			TestBasicBoostPathing();
+			TestAdvancedBoostPathing();
+			TestBoostPadDetection();
+			
+			std::cout << "\n=== Tests Complete ===" << std::endl;
+		}
+	}
+}
+
+// Example usage in main function (uncomment to test)
+/*
+int main() {
+    RLGSC::BoostPathingTest::RunAllTests();
+    return 0;
+}
+*/

--- a/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/README_BoostPathing.md
+++ b/RLGymPPO_CPP/RLGymSim_CPP/src/RLGymSim_CPP/Utils/RewardFunctions/README_BoostPathing.md
@@ -1,0 +1,285 @@
+# Boost Pathing Reward Functions for RLGymPPO-CPP
+
+This directory contains advanced reward functions designed to train Rocket League bots with sophisticated boost management skills. The reward functions encourage efficient boost collection behavior through multiple mechanisms.
+
+## Overview
+
+Boost pathing is a crucial skill in Rocket League that involves:
+- Efficiently collecting boost pads while maintaining game flow
+- Prioritizing boost pads based on type (large vs small) and location
+- Timing boost collection to maximize efficiency
+- Managing boost levels to avoid starvation
+
+## Files
+
+### Core Implementation
+- `BoostPathingReward.h/cpp` - Basic boost pathing reward function
+- `AdvancedBoostPathingReward.h/cpp` - Advanced version with timing and strategic rewards
+- `BoostPathingExample.cpp` - Usage examples and documentation
+
+## Reward Components
+
+### 1. Proximity Rewards
+Rewards the agent for being near active boost pads.
+- **Purpose**: Encourages the agent to stay near boost sources
+- **Scaling**: Distance-based (closer = higher reward)
+- **Differentiation**: Large pads (100 boost) get higher rewards than small pads (12 boost)
+
+### 2. Collection Rewards
+Rewards successful boost pad collection.
+- **Purpose**: Reinforces successful boost gathering
+- **Intentionality**: Only rewards collection if the pad was nearby in the previous frame
+- **Multipliers**: Different rewards for different pad types
+
+### 3. Pathing Rewards
+Rewards movement toward nearby boost pads.
+- **Purpose**: Encourages intentional movement toward boost
+- **Method**: Uses dot product to measure alignment with pad direction
+- **Scaling**: Distance-based scaling
+
+### 4. Timing Rewards (Advanced)
+Rewards collecting pads just as they spawn.
+- **Purpose**: Encourages efficient timing and prediction
+- **Window**: Configurable time window after spawn
+- **Strategy**: Higher rewards for quick collection
+
+### 5. Efficiency Rewards
+Rewards being near boost when boost is low.
+- **Purpose**: Prevents boost starvation
+- **Threshold**: Configurable boost level threshold
+- **Proactivity**: Encourages proactive boost management
+
+### 6. Strategic Rewards (Advanced)
+Rewards choosing high-priority boost pads.
+- **Purpose**: Encourages strategic decision making
+- **Factors**: Considers pad type, location, and distance
+- **Priority**: Calculates pad priorities based on multiple factors
+
+## Boost Pad Information
+
+### Pad Types
+- **Large Pads (100 boost)**: Center field, corners, back walls
+- **Small Pads (12 boost)**: Distributed throughout the field
+
+### Pad Locations
+The system uses the standard Rocket League boost pad locations:
+- 34 total boost pads
+- All positions hardcoded in `CommonValues::BOOST_LOCATIONS`
+- Automatic detection of large vs small pads
+
+### Pad States
+- **Active**: Pad is available for collection
+- **Inactive**: Pad is on cooldown
+- **Cooldown Timer**: Time remaining until pad respawns
+
+## Configuration
+
+### Basic Configuration (BoostPathingReward)
+```cpp
+BoostPathingReward::Config config;
+config.proximityReward = 0.1f;        // Reward for being near boost pads
+config.collectionReward = 1.0f;       // Reward for collecting boost pads
+config.pathingReward = 0.05f;         // Reward for moving toward boost pads
+config.efficiencyReward = 0.2f;       // Reward for efficient boost usage
+config.proximityThreshold = 300.0f;   // Distance threshold for "nearby" pads
+config.collectionThreshold = 100.0f;  // Distance threshold for collection
+config.boostEfficiencyThreshold = 0.3f; // Boost level below which efficiency is rewarded
+```
+
+### Advanced Configuration (AdvancedBoostPathingReward)
+```cpp
+AdvancedBoostPathingReward::Config config;
+// Basic rewards
+config.proximityReward = 0.05f;
+config.collectionReward = 1.0f;
+config.pathingReward = 0.03f;
+
+// Timing-based rewards
+config.timingReward = 0.2f;           // Reward for collecting pads just as they spawn
+config.efficiencyReward = 0.15f;      // Reward for efficient boost usage
+config.strategicReward = 0.1f;        // Reward for strategic pad selection
+
+// Thresholds
+config.proximityThreshold = 400.0f;
+config.collectionThreshold = 120.0f;
+config.boostEfficiencyThreshold = 0.4f;
+config.timingWindow = 0.5f;           // seconds after pad spawn to get timing reward
+
+// Strategic parameters
+config.largePadPreference = 2.0f;     // Multiplier for preferring large pads
+config.backWallPreference = 1.5f;     // Multiplier for back wall pads
+config.centerPreference = 1.3f;       // Multiplier for center pads
+```
+
+## Usage Examples
+
+### Basic Usage
+```cpp
+#include "BoostPathingReward.h"
+
+// Create basic boost pathing reward
+BoostPathingReward::Config config;
+config.proximityReward = 0.1f;
+config.collectionReward = 1.0f;
+auto reward = std::make_shared<BoostPathingReward>(config);
+```
+
+### Advanced Usage
+```cpp
+#include "AdvancedBoostPathingReward.h"
+
+// Create advanced boost pathing reward
+AdvancedBoostPathingReward::Config config;
+config.timingReward = 0.2f;
+config.strategicReward = 0.1f;
+auto reward = std::make_shared<AdvancedBoostPathingReward>(config);
+```
+
+### Combined with Other Rewards
+```cpp
+#include "BoostPathingExample.cpp"
+
+// Use the provided examples
+auto reward = BoostPathingExamples::CreateCombinedBoostPathingReward();
+```
+
+### Play Style Specialization
+```cpp
+// Aggressive play style - prioritize large pads and timing
+auto aggressiveReward = BoostPathingExamples::CreateAggressiveBoostPathingReward();
+
+// Conservative play style - prioritize efficiency and small pads
+auto conservativeReward = BoostPathingExamples::CreateConservativeBoostPathingReward();
+```
+
+## Integration with Training
+
+### 1. Add to Your Training Setup
+```cpp
+// In your main training file
+#include "Utils/RewardFunctions/BoostPathingReward.h"
+#include "Utils/RewardFunctions/AdvancedBoostPathingReward.h"
+
+// Create reward function
+auto boostPathingReward = BoostPathingExamples::CreateAdvancedBoostPathingReward();
+
+// Add to your environment configuration
+// (Implementation depends on your specific setup)
+```
+
+### 2. Combine with Existing Rewards
+```cpp
+#include "Utils/RewardFunctions/CombinedReward.h"
+
+std::vector<std::shared_ptr<RewardFunction>> rewards = {
+    boostPathingReward,
+    velocityReward,
+    touchBallReward,
+    eventReward
+};
+
+auto combinedReward = std::make_shared<CombinedReward>(rewards);
+```
+
+### 3. Tune Parameters
+Start with the provided examples and adjust parameters based on:
+- Training progress
+- Desired play style
+- Performance metrics
+- Boost collection efficiency
+
+## Performance Considerations
+
+### Memory Usage
+- Player histories are kept for 2 seconds
+- Boost pad states are tracked for all 34 pads
+- Minimal memory overhead per player
+
+### Computational Cost
+- Distance calculations for all active boost pads
+- Historical data updates every frame
+- Priority calculations for strategic rewards
+- Overall impact: Low to moderate
+
+### Optimization Tips
+- Use basic reward for initial training
+- Switch to advanced reward for fine-tuning
+- Adjust thresholds based on performance
+- Monitor boost collection rates during training
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No boost collection rewards**
+   - Check if boost pads are active in the game state
+   - Verify proximity thresholds are appropriate
+   - Ensure player is close enough to collect
+
+2. **Too many/few rewards**
+   - Adjust reward magnitudes in configuration
+   - Tune proximity and collection thresholds
+   - Balance with other reward components
+
+3. **Poor boost pathing behavior**
+   - Increase pathing reward magnitude
+   - Adjust proximity threshold
+   - Consider using advanced reward with timing
+
+### Debugging
+- Monitor reward values during training
+- Check boost pad states and player positions
+- Verify configuration parameters
+- Use logging to track reward components
+
+## Best Practices
+
+### Training Strategy
+1. Start with basic reward function
+2. Gradually increase complexity
+3. Monitor boost collection efficiency
+4. Adjust parameters based on performance
+5. Consider play style specialization
+
+### Parameter Tuning
+1. Begin with example configurations
+2. Adjust one parameter at a time
+3. Monitor training metrics
+4. Balance with other rewards
+5. Test in actual gameplay
+
+### Integration
+1. Combine with existing reward functions
+2. Maintain reward balance
+3. Consider team coordination
+4. Adapt to different game modes
+5. Test with different skill levels
+
+## Future Enhancements
+
+### Potential Improvements
+- Team coordination rewards
+- Opponent boost denial
+- Boost pad prediction
+- Dynamic priority adjustment
+- Game state awareness
+
+### Advanced Features
+- Boost pad timing prediction
+- Strategic boost denial
+- Team boost management
+- Adaptive reward scaling
+- Performance-based tuning
+
+## Contributing
+
+When contributing to the boost pathing reward functions:
+1. Follow the existing code style
+2. Add comprehensive documentation
+3. Include usage examples
+4. Test with different configurations
+5. Consider performance implications
+
+## License
+
+This implementation follows the same license as the RLGymPPO-CPP framework.


### PR DESCRIPTION
Introduce comprehensive boost pathing reward functions to enable training of Rocket League bots with sophisticated boost management skills.

This PR adds `BoostPathingReward` and `AdvancedBoostPathingReward` which provide proximity, collection, pathing, timing, efficiency, and strategic rewards for boost pads, along with usage examples and documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2232c340-e265-461f-819c-10acde3004a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2232c340-e265-461f-819c-10acde3004a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

