### PR TITLE
Improve aerial touch and air roll reward

### DIFF
--- a/JumpTouchReward.cpp
+++ b/JumpTouchReward.cpp
@@ -1,0 +1,112 @@
+#include "JumpTouchReward.h"
+#include <iostream>
+
+namespace RLGSC {
+
+    float JumpTouchReward::GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) {
+        float reward = 0.0f;
+        float air_roll_reward = 0.0f;
+        float touch_reward = 0.0f;
+        
+        const Vec& car_pos = player.phys.pos;
+        const Vec& ball_pos = state.ball.pos;
+        bool is_airborne = !player.carState.isOnGround && car_pos.z >= this->air_roll_min_height;
+        
+        Vec dist_vec = ball_pos - car_pos;
+        float dist = dist_vec.Length();
+        
+        // 1. JUMP TOUCH REWARD
+        if (player.ballTouchedStep && is_airborne && ball_pos.z >= minHeight) {
+            float heightAboveMin = ball_pos.z - minHeight;
+            float height_factor = std::clamp(heightAboveMin / range, 0.0f, 1.0f);
+            touch_reward = height_factor * 1.0f;
+            
+            float ball_speed = state.ball.vel.Length();
+            if (ball_speed > 300.0f) {
+                float speed_factor = std::min(1.0f, ball_speed / 2000.0f);
+                touch_reward *= (1.0f + speed_factor);
+            }
+            
+            float direction_factor = 0.0f;
+            if (player.team == Team::BLUE && state.ball.vel.y > 0) {
+                direction_factor = std::min(1.0f, state.ball.vel.y / 1000.0f);
+            } else if (player.team == Team::ORANGE && state.ball.vel.y < 0) {
+                direction_factor = std::min(1.0f, -state.ball.vel.y / 1000.0f);
+            }
+            touch_reward *= (1.0f + direction_factor * 0.5f);
+            
+            reward += touch_reward;
+        }
+        
+        // 2. AIR ROLL REWARD
+        if (is_airborne) {
+            float current_roll_input = prevAction.roll;
+            
+            if (std::abs(current_roll_input) > 0.1f && std::abs(this->last_roll_input) > 0.1f) {
+                if ((current_roll_input * this->last_roll_input) < 0) this->direction_changes++;
+            }
+            if (this->direction_changes > 0) this->direction_changes = std::max(0, this->direction_changes - 1);
+            
+            this->cumulative_roll_direction = (this->cumulative_roll_direction + current_roll_input) * 0.98f;
+            
+            bool is_wiggling = this->direction_changes > MAX_DIRECTION_CHANGES;
+            
+            if (!is_wiggling && std::abs(current_roll_input) > 0.1f) {
+                float current_angular_vel = player.phys.angVel.y;
+                float roll_angular_vel = std::abs(current_angular_vel);
+                float roll_intensity = std::min(1.0f, roll_angular_vel / CommonValues::CAR_MAX_ANG_VEL);
+                
+                air_roll_reward = roll_intensity * this->air_roll_weight;
+                
+                if (current_roll_input > 0.1f) {
+                    air_roll_reward *= 1.5f;
+                    if (this->cumulative_roll_direction > 2.0f) air_roll_reward *= 1.3f;
+                } else {
+                    air_roll_reward *= 0.3f;
+                }
+                
+                if (prevAction.boost && player.boostFraction > 0.2f) air_roll_reward *= 1.4f;
+                
+                // --- ENHANCED INTERCEPTION REWARD ---
+                // Increased distance threshold and made the reward much stronger
+                if (dist < 1500.0f && ball_pos.z > 200.0f) {
+                    float speed_towards_ball = 0.f;
+                    if (dist > 1e-6f) speed_towards_ball = player.phys.vel.Dot(dist_vec / dist);
+                    
+                    if(speed_towards_ball > 50.0f) { // Lowered threshold to catch earlier approach
+                        // Much stronger multiplier for approach phase
+                        float approach_multiplier = 5.0f; // Increased from 2.5f
+                        
+                        // Distance-based scaling - closer = higher reward
+                        float distance_factor = 1.0f - (dist / 1500.0f);
+                        approach_multiplier *= (1.0f + distance_factor);
+                        
+                        // Speed towards ball bonus
+                        float speed_bonus = std::min(1.0f, speed_towards_ball / 500.0f);
+                        approach_multiplier *= (1.0f + speed_bonus);
+                        
+                        air_roll_reward *= approach_multiplier;
+                        
+                        // Extra bonus for roll intensity during approach
+                        air_roll_reward *= (1.0f + roll_intensity * 1.0f);
+                    }
+                }
+
+                // --- REDUCED POST-TOUCH REWARD ---
+                // Only give a small bonus if air rolling during/after touch, not a major multiplier
+                if (player.ballTouchedStep) {
+                    air_roll_reward *= 1.1f; // Reduced from 1.5f to discourage farming
+                }
+            }
+            
+            this->last_roll_input = current_roll_input;
+        } else {
+            this->last_roll_input = 0.0f;
+            this->direction_changes = 0;
+            this->cumulative_roll_direction = 0.0f;
+        }
+        
+        reward += air_roll_reward;
+        return reward;
+    }
+} // namespace RLGSC

--- a/JumpTouchReward.h
+++ b/JumpTouchReward.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <RLGymSim_CPP/Utils/RewardFunctions/RewardFunction.h>
+#include <RLGymSim_CPP/Utils/Gamestates/GameState.h>
+#include <RLGymSim_CPP/Utils/CommonValues.h>
+#include <algorithm> // For std::clamp
+#include <cmath> // For std::abs
+
+namespace RLGSC {
+    /**
+     * Enhanced JumpTouchReward - Rewards touching the ball while airborne with air roll
+     * 
+     * This reward function has two main components:
+     * 1. Jump Touch Reward: Rewards for touching the ball in the air, scaled by height
+     * 2. Air Roll Reward: Rewards for air rolling, especially when approaching and touching the ball
+     * 
+     * The air roll component is designed to encourage the agent to air roll during aerial
+     * challenges and 50/50s, similar to how human players use air roll for better control.
+     * 
+     * Key improvements:
+     * - Stronger rewards during approach phase (5x multiplier + distance/speed bonuses)
+     * - Reduced post-touch farming (1.1x instead of 1.5x)
+     * - Larger interception distance threshold (1500 units)
+     * - Lower speed threshold for earlier reward activation
+     */
+    class JumpTouchReward : public RewardFunction {
+    public:
+        // Core parameters
+        float minHeight;        // Minimum height for jump touch rewards
+        float maxHeight;        // Maximum height for scaling rewards
+        float range;            // Calculated range between min and max height
+        float air_roll_weight;  // Weight for air roll rewards
+        float air_roll_min_height; // Minimum height for air roll rewards
+
+        /**
+         * Constructor to set reward parameters
+         * 
+         * @param minHeight Minimum ball height for jump touch rewards
+         * @param maxHeight Maximum ball height for scaling rewards
+         * @param airRollWeight Weight for air roll rewards
+         * @param airRollMinHeight Minimum car height for air roll rewards
+         */
+        JumpTouchReward(float minHeight = 120.0f, float maxHeight = 1000.0f, 
+                        float airRollWeight = 2.5f, float airRollMinHeight = 160.0f)
+            : minHeight(minHeight), maxHeight(maxHeight), range(maxHeight - minHeight), 
+              air_roll_weight(airRollWeight), air_roll_min_height(airRollMinHeight),
+              last_roll_input(0.0f), direction_changes(0), cumulative_roll_direction(0.0f) {
+                // Ensure range is positive to avoid division issues
+                if (range <= 0) {
+                    this->range = 1.0f;
+                }
+            }
+
+        // Reset air roll tracking state
+        virtual void Reset(const GameState& initialState) override {
+            last_roll_input = 0.0f;
+            direction_changes = 0;
+            cumulative_roll_direction = 0.0f;
+        }
+
+        // Calculate reward per step
+        virtual float GetReward(const PlayerData& player, const GameState& state, const Action& prevAction) override;
+
+    private:
+        // Air roll tracking variables
+        float last_roll_input;
+        int direction_changes;
+        float cumulative_roll_direction;
+        
+        // Constants
+        static constexpr int MAX_DIRECTION_CHANGES = 2;
+    };
+} // namespace RLGSC


### PR DESCRIPTION
Adjust `JumpTouchReward` to prioritize air rolling during aerial approach over post-touch farming.

Previously, the reward structure inadvertently incentivized agents to perform simple aerials and then air roll *after* touching the ball to gain rewards. This update significantly boosts the air roll reward during the approach phase, making it more beneficial to use air roll for control *before* contact, while reducing the post-touch bonus.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9aa3b94-6cf8-4633-90e0-bb7006512bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9aa3b94-6cf8-4633-90e0-bb7006512bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

